### PR TITLE
EP-21998: fix empty pkgName, save pkgfiles delim

### DIFF
--- a/lib/modules/manager/pip_requirements/extract.ts
+++ b/lib/modules/manager/pip_requirements/extract.ts
@@ -116,6 +116,7 @@ export function extractPackageFile(content: string): PackageFileContent | null {
         depName,
         currentValue,
         datasource: PypiDatasource.id,
+        packageName: depName,
       };
       if (currentValue?.startsWith('==')) {
         dep.currentVersion = currentValue.replace(/^==\s*/, '');

--- a/lib/workers/repository/process/extract-update.ts
+++ b/lib/workers/repository/process/extract-update.ts
@@ -202,7 +202,7 @@ function savePackageFiles(
   const directory = [root, org].join('/');
   const filepath = [
     directory,
-    [repo, baseBranch, 'package-files.json'].join('-'),
+    [repo, baseBranch, 'package-files.json'].join(','),
   ].join('/');
   try {
     fs.mkdirSync(directory, { recursive: true });


### PR DESCRIPTION
* fix empty pkgName causes regeneration of branch data even if there is no change in branch
* add comma a delimiter for saving pkgfiles